### PR TITLE
Fix static files hosting & validationUrl

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -20,7 +20,8 @@ const app = express();
 require('{%= name %}')({
   app       : app,
   swaggerUrl: '/swagger.json',  // this is the default value
-  localPath : '/explorer'       // this is the default value
+  localPath : '/explorer',       // this is the default value
+  validatorUrl : 'http://online.swagger.io/validator'    // optional custom validator url or null to disable 
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,14 @@ function initializeExpressUi(options)
   if(!options.html) {
     options.html = fs
       .readFileSync(path.join(swaggerUi.dist,'index.html'),{encoding:'utf-8'})
-      .replace('http://petstore.swagger.io/v2/swagger.json', options.swaggerUrl);
+      .replace('http://petstore.swagger.io/v2/swagger.json', options.swaggerUrl)
+      .replace('</title>', '</title><base href="' + options.localPath + '/">');
+
+    // Set validatorUrl to null or string if set
+    if(options.hasOwnProperty('validatorUrl')){
+      options.html = options.html
+      .replace('new SwaggerUi({','new SwaggerUi({ validatorUrl: ' + (options.validatorUrl ? '"' + options.validatorUrl + '"' : null) +  ',');      
+    }
   }
 
   options.app


### PR DESCRIPTION
The html file points to files on the root so this injects a `<base>` tag to point to where the static files are served from.

Also, allow the validatorUrl to be set to null or another location for local testing.
